### PR TITLE
Fix documentHighlight on TypeScript 2.9

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -458,7 +458,7 @@ export class Session {
     public documentHighlight(textDocumentPosition: TextDocumentPositionParams): DocumentHighlight[] {
         return this.getProjectScriptInfoAt(textDocumentPosition)
             .map(({project, scriptInfo, position}) => {
-                const highlights = project.getLanguageService().getDocumentHighlights(scriptInfo.fileName, position, []);
+                const highlights = project.getLanguageService().getDocumentHighlights(scriptInfo.fileName, position, [scriptInfo.fileName]);
                 if (highlights) {
                     const fileHighlights = highlights.find(hl => hl.fileName === scriptInfo.fileName);
                     if (fileHighlights) {


### PR DESCRIPTION
In TypeScript 2.9, there's an additional check test `documentHighlights` "respecting" `filesToSearch` (third argument). This Fixes #1 