### PR TITLE
fix: map parameter to variable in completions

### DIFF
--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -27,7 +27,8 @@ export const completionKinds: { [name: string]: CompletionItemKind } = {
     let: CompletionItemKind.Variable,
     string: CompletionItemKind.Constant,
     directory: CompletionItemKind.Folder,
-    jsxAttribute: CompletionItemKind.Property
+    jsxAttribute: CompletionItemKind.Property,
+    parameter: CompletionItemKind.Variable
 };
 
 completionKinds[ts.ScriptElementKind.localFunctionElement] = CompletionItemKind.Function;


### PR DESCRIPTION
Function parameters were not labeled in the completion popup. I think "Variable" is the most fitting. Parameter doesn't exist in languageserver types as far as I can see.